### PR TITLE
Do not interpret non-empty stderr as error

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -10,9 +10,8 @@ const exec = require('ssh-exec')
  */
 module.exports = (command, options) =>
   new Promise((resolve, reject) => {
-    exec(command, options, (err, stdout, stderr) => {
+    exec(command, options, (err, stdout) => {
       if (err) return reject(err)
-      if (stderr) return reject(new Error(stderr))
       resolve(stdout)
     })
   })

--- a/src/publish.js
+++ b/src/publish.js
@@ -22,6 +22,7 @@ module.exports = async (pluginConfig, ctx) => {
     }
     const command = `export VERSION=${ctx.nextRelease.version};\n${pluginConfig.publishCmd}`
     await exec(command, options)
+    return undefined
   } catch (err) {
     ctx.message = err.message
     throw getError('ESSHCOMMAND', ctx)

--- a/src/publish.js
+++ b/src/publish.js
@@ -22,7 +22,6 @@ module.exports = async (pluginConfig, ctx) => {
     }
     const command = `export VERSION=${ctx.nextRelease.version};\n${pluginConfig.publishCmd}`
     await exec(command, options)
-    return undefined
   } catch (err) {
     ctx.message = err.message
     throw getError('ESSHCOMMAND', ctx)

--- a/src/publish.js
+++ b/src/publish.js
@@ -21,7 +21,7 @@ module.exports = async (pluginConfig, ctx) => {
       options.key = ctx.env.SSH_PRIVATE_KEY
     }
     const command = `export VERSION=${ctx.nextRelease.version};\n${pluginConfig.publishCmd}`
-    return await exec(command, options)
+    await exec(command, options)
   } catch (err) {
     ctx.message = err.message
     throw getError('ESSHCOMMAND', ctx)


### PR DESCRIPTION
Unfortunately, stderr is kinda often used although there is no error. If there is an error, a non-zero error code should be returned. Webpack for example sometimes writes to stderr. This PR removes the line where stderr leads to an exception.