### PR TITLE
Support node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "nyc mocha test"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
In fact there is no reason to restrict node to versions above 12, since 10 is also supported.